### PR TITLE
Changed auth, validate and refresh step to detect Cloudflare blocking

### DIFF
--- a/libs/tokens-use.js
+++ b/libs/tokens-use.js
@@ -46,7 +46,7 @@ module.exports = (_opt, _cb) => {
       if(_err){
         debug('Password authentification impossible ('+_err+')');
         delete options.password;
-        if (_err === 'Request blocked by CloudFlare') {
+        if (_err.message === 'Request blocked by CloudFlare') {
           return error(_err)
         }
         return resetTokens();
@@ -90,12 +90,12 @@ module.exports = (_opt, _cb) => {
             debug('accessToken still ok !');
             return finish();
           } else { //Session is outdated, try to refresh it
-            if (_err === 'Request blocked by CloudFlare') {
+            if (_err.message === 'Request blocked by CloudFlare') {
               return error(_err)
             }
             debug('Token outdated - try to refresh it');
             yggdrasil.refresh(options.session.accessToken, options.clientToken, function(_err, _accessToken, _data) {
-              if (_err === 'Request blocked by CloudFlare') {
+              if (_err.message === 'Request blocked by CloudFlare') {
                 return error(_err)
               }
               //Error - reset of accessToken

--- a/libs/tokens-use.js
+++ b/libs/tokens-use.js
@@ -46,6 +46,9 @@ module.exports = (_opt, _cb) => {
       if(_err){
         debug('Password authentification impossible ('+_err+')');
         delete options.password;
+        if (_err === 'Request blocked by CloudFlare') {
+          return error(_err)
+        }
         return resetTokens();
       }
       debug('accessToken reset (new value: '+_data.accessToken+')');
@@ -87,8 +90,14 @@ module.exports = (_opt, _cb) => {
             debug('accessToken still ok !');
             return finish();
           } else { //Session is outdated, try to refresh it
+            if (_err === 'Request blocked by CloudFlare') {
+              return error(_err)
+            }
             debug('Token outdated - try to refresh it');
             yggdrasil.refresh(options.session.accessToken, options.clientToken, function(_err, _accessToken, _data) {
+              if (_err === 'Request blocked by CloudFlare') {
+                return error(_err)
+              }
               //Error - reset of accessToken
               if(_err || _accessToken === null){
                 debug('Invalid token. - new one from password authentication');


### PR DESCRIPTION
Currently prismarine-tokens returns no error if the authentication request was blocked by Cloudflare. The yggdrasil function used by prismarine-tokens can however detect if a request was block. 

https://github.com/PrismarineJS/node-yggdrasil/blob/9fda7ea36bbcc8cc54fe3595d7cb8b81bc6e3d56/lib/utils.js#L45

With this change the use function returns an error with the message Blocked by Cloudflare.